### PR TITLE
Removed lsp4jakarta jar from classpath of jdt extension

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/META-INF/MANIFEST.MF
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/META-INF/MANIFEST.MF
@@ -29,14 +29,14 @@ Require-Bundle:
  org.eclipse.lsp4j.jsonrpc,
  org.eclipse.lsp4j,
  com.google.gson,
+ com.google.guava,
  org.eclipse.jdt.ui,
  org.jsoup;bundle-version="1.8.3",
  org.apache.commons.io,
  org.apache.commons.lang3
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: lsp4jakarta-1.0-SNAPSHOT-jar-with-dependencies.jar,
- .
+Bundle-ClassPath: .
 Export-Package: 
  org.eclipse.lsp4jakarta.commons, 
  org.eclipse.lsp4jakarta.jdt.core

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/pom.xml
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/pom.xml
@@ -242,33 +242,7 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-
 	</build>
-	
-	<dependencies>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.8.5</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.lsp4mp</groupId>
-			<artifactId>org.eclipse.lsp4mp.ls</artifactId>
-			<version>0.9.0-SNAPSHOT</version>
-			<classifier>uber</classifier>
-			<exclusions>
-				<exclusion>
-					<groupId>org.eclipse.lsp4j</groupId>
-					<artifactId>org.eclipse.lsp4j</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.eclipse.lsp4j</groupId>
-					<artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-	</dependencies>
-
 
 </project>
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/DocumentFormat.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/DocumentFormat.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4jakarta.commons;
+
+/**
+ * Reused from
+ * https://raw.githubusercontent.com/eclipse/lsp4mp/master/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/DocumentFormat.java
+ *
+ * @author Angelo ZERR
+ */
+public enum DocumentFormat {
+
+    PlainText(1), Markdown(2);
+
+    private final int value;
+
+    DocumentFormat(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static DocumentFormat forValue(int value) {
+        DocumentFormat[] allValues = DocumentFormat.values();
+        if (value < 1 || value > allValues.length)
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
+    }
+
+}


### PR DESCRIPTION
With this change we no longer need to include the `lsp4jakarta-1.0-SNAPSHOT-jar-with-dependencies.jar` in the jdt extension project. 

You no longer need to include that jar in the `/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core` directory

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>